### PR TITLE
Create longestcommonprefix.cpp

### DIFF
--- a/longestcommonprefix.cpp
+++ b/longestcommonprefix.cpp
@@ -1,0 +1,29 @@
+class Solution {
+public:
+    int longestCommonPrefix(vector<int>& arr1, vector<int>& arr2) {
+        unordered_set<int> prefixes;  // Set to store all prefixes from arr1
+
+        // Step 1: Build all possible prefixes from arr1
+        for (int val : arr1) {
+            while (!prefixes.count(val) && val > 0) {
+                prefixes.insert(val);  // Insert current value as a prefix
+                val /= 10;  // Generate the next shorter prefix by removing the last digit
+            }
+        }
+
+        int longestPrefix = 0;
+
+        // Step 2: Check each number in arr2 for the longest matching prefix
+        for (int val : arr2) {
+            while (!prefixes.count(val) && val > 0) {
+                val /= 10;  // Reduce val by removing the last digit if not found in the prefix set
+            }
+            if (val > 0) {
+                // Calculate the length of the matched prefix using log10 to determine the number of digits
+                longestPrefix = max(longestPrefix, static_cast<int>(log10(val) + 1));
+            }
+        }
+
+        return longestPrefix;
+    }
+};


### PR DESCRIPTION
You are given two arrays with positive integers arr1 and arr2.

A prefix of a positive integer is an integer formed by one or more of its digits, starting from its leftmost digit. For example, 123 is a prefix of the integer 12345, while 234 is not.

A common prefix of two integers a and b is an integer c, such that c is a prefix of both a and b. For example, 5655359 and 56554 have a common prefix 565 while 1223 and 43456 do not have a common prefix.

You need to find the length of the longest common prefix between all pairs of integers (x, y) such that x belongs to arr1 and y belongs to arr2.

Return the length of the longest common prefix among all pairs. If no common prefix exists among them, return 0.

 

Example 1:

Input: arr1 = [1,10,100], arr2 = [1000]
Output: 3
Explanation: There are 3 pairs (arr1[i], arr2[j]):
- The longest common prefix of (1, 1000) is 1.
- The longest common prefix of (10, 1000) is 10.
- The longest common prefix of (100, 1000) is 100.
The longest common prefix is 100 with a length of 3.